### PR TITLE
Fix: Adjust Image and Remove business hours

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,20 @@ function App() {
         <div className="p-5">
             <Container>
                 <Row>
+                    <Col
+                        justify_content={"center"}
+                        md={5}
+                    >
+                        <Image
+                            src="/images/Table Setup.jpg"
+                            alt="Massage photo"
+                            fluid
+                            className="rounded shadow"
+                        />
+                    </Col>
+                    <br />
+                    <br />
+                    <br />
                     <Col md={7}>
                         <h1>Jordan Brisson Mobile Massage Therapy</h1>
                         <h4 style={{ fontStyle: "italic" }}>Your home, your haven.</h4>
@@ -39,14 +53,6 @@ function App() {
                         </p>
                         <br />
                         <i><h3>Direct billing is now offered for most insurance companies</h3></i>
-                    </Col>
-                    <Col md={5}>
-                        <Image
-                            src="/images/Table Setup.jpg"
-                            alt="Massage photo"
-                            fluid
-                            className="rounded shadow"
-                        />
                     </Col>
                 </Row>
             </Container>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -6,22 +6,14 @@ const Footer = () => {
         <footer className="bg-dark py-4 bottom-0 w-100">
             <Container>
                 <Row className="">
-                    <Col md="4">
-                        <h5 className="text-white">Hours of Operation</h5>
-                        <ul className="list-unstyled">
-                            <li className="text-white">Tuesday: 4:00PM-8:00PM</li>
-                            <li className="text-white">Thursday: 9:00AM-1:00PM</li>
-                            <li className="text-white">Saturday: 9:00AM-5:00PM</li>
-                        </ul>
-                    </Col>
-                    <Col md="4">
+                    <Col md="6">
                         <h5 className="text-white">Contact Information</h5>
                         <ul className="list-unstyled">
                             <li className="text-white">Phone: (519) 872-0460</li>
                             <li className="text-white">Email: jordan.b@live.ca</li>
                         </ul>
                     </Col>
-                    <Col md="4" className="text-md-end">
+                    <Col justify_content="center" md="6" className="text-md-end">
                         <p className="text-white">Jordan Brission Mobile Massage Therapy</p>
                     </Col>
                 </Row>


### PR DESCRIPTION
Removing the business hours as they vary a lot, and then adjust the mobile image to appear above the main text